### PR TITLE
manifest: remove --device=all because the app works without

### DIFF
--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=fallback-x11
   - --socket=wayland
   - --socket=pulseaudio
-  - --device=all
   - --filesystem=xdg-desktop
   - --filesystem=xdg-download
   - --filesystem=xdg-music


### PR DESCRIPTION
This reduces the attack surface.

#38 