### PR TITLE
Release 4.5.0

### DIFF
--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -758,11 +758,11 @@ modules:
       - mkdir -p ${FLATPAK_DEST}/extensions/cpu
       - cd python && python setup.py bdist_wheel
       - pip3 install --verbose --exists-action=i --no-index --prefix=${FLATPAK_DEST}/extensions/cpu --no-build-isolation python/dist/*.whl
-      - strip ${FLATPAK_DEST}/extensions/cpu/lib/libctranslate2.so.4.1.0
+      - strip ${FLATPAK_DEST}/extensions/cpu/lib/libctranslate2.so.4.2.1
     sources:
       - type: git
         url: https://github.com/OpenNMT/CTranslate2.git
-        commit: bfa0cb3c03ba02df0d53659aa5235611d701c574
+        commit: 0527ef7a2988f0b65b2c534168ae2df687ed9dc6
       - type: patch
         path: patches/ctranslate2.patch
 
@@ -846,4 +846,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/mkiol/dsnote.git
-        commit: 8442c911ebe2767ac4e381aafe5fb6072b343dc2
+        commit: 2212f07576781232dbba9986bef9aebfc0fc9728

--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -846,4 +846,4 @@ modules:
     sources:
       - type: git
         url: https://github.com/mkiol/dsnote.git
-        commit: 2212f07576781232dbba9986bef9aebfc0fc9728
+        commit: 8d9dcb0595f7fa3ad9e2f53975d3f80a5c5e2973

--- a/python3-modules-x86-64.yaml
+++ b/python3-modules-x86-64.yaml
@@ -587,7 +587,7 @@ modules:
         PYTHONPATH: /app/extensions/cpu/lib/python3.11/site-packages:/app/lib/python3.11/site-packages
     build-commands:
       - pip3 install --verbose --exists-action=i --no-index --find-links="file://${PWD}"
-        --prefix=${FLATPAK_DEST} "faster-whisper==1.0.1" --no-build-isolation
+        --prefix=${FLATPAK_DEST} "faster-whisper==1.0.2" --no-build-isolation
     sources:
       - *id023
       - type: file
@@ -602,8 +602,8 @@ modules:
         url: https://files.pythonhosted.org/packages/60/6c/e38303443479483fb0900256b2cda80ae11e9c162e784a8b73f46672be93/ctranslate2-4.0.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
         sha256: 8c185580ef598c45e343ec3af33bcdb634c723100aef01d26b937da7b2f263dc
       - type: file
-        url: https://files.pythonhosted.org/packages/2b/3c/afdc84846ea13933876e8ca32c58d64cd4361fddfc6ede34c0ca3f0105ce/faster_whisper-1.0.1-py3-none-any.whl
-        sha256: 7803bf7abcaae0376158d7b064ba927d44b6ce1fa9f6250d6d13038354d1d01a
+        url: https://files.pythonhosted.org/packages/4e/77/3f7474863c99732edadcd5a7fc34ba5779b0bd71610ede65182fd2610323/faster_whisper-1.0.2-py3-none-any.whl
+        sha256: d968c289222e766a49ed97eecec24e934bdef405183f57d6d434a364bb3569c1
       - *id004
       - type: file
         url: https://files.pythonhosted.org/packages/6f/12/d5c79ee252793ffe845d58a913197bfa02ae9a0b5c9bc3dc4b58d477b9e7/flatbuffers-23.5.26-py2.py3-none-any.whl


### PR DESCRIPTION
Changes:

- User Interface
  - Import subtitles embedded into video file. If your video file contains one or many subtitle streams, you can import the selected subtitles into notepad
  - Support for more subtitles formats. You can import and export subtitles in SRT, WebVTT and ASS formats.
  - Unified file importing and exporting. Text, subtitles, audio and video files can be imported or exported using unified menu bar option.
  - Settings option to enable/disable remembering the last note. If the option is disabled, the last note will not be available after restarting the app.
  - Settings option for default action when importing note from a file. You can set <i>Ask whether to add or replace</i>, <i>Add to an existing note</i> or <i>Replace an existing note</i>.
  - Enhanced text editor font settings. You can set the font family, style and size of the font used in the text editor.
  - Text to Text repair options. With these options you can directly fix diacritical marks and punctuation in the text.
  - Text context menu with additional options: <i>Read selection</i> and <i>Translate selection</i>. To activate context menu use mouse right click.
  - New text appending style: <i>After empty line</i>
  - System tray menu for changing active STT/TTS model
  - User friendly names of audio input devices
  - Simplified model filtering. It is now less flexible, but much easier to understand and use.
  - <i>Speech Note</i> has been translated into Ukrainian and Russian languages.
  - Fix: Cancellation was blocking the user interface.
- Speech to Text
  - Updated [Distil](https://huggingface.co/distil-whisper/distil-large-v3) model for English: <i>Distil Large-v3</i>. New model is enabled for Whisper and Faster Whisper engines.
  - New Fine-Tuned Whisper models for [Slovenian](https://huggingface.co/samolego/whisper-small-slovenian) and [Polish](https://huggingface.co/Aspik101/distil-whisper-large-v3-pl)
  - Fix: Punctuation model could not be downloaded.</li>
- Text to Speech
  - [WhisperSpeech](https://collabora.github.io/WhisperSpeech) engine that generates voice with exceptional naturalness. The new engine comes with models for English and Polish languages. All models support voice cloning.
  - New voice cloning model for Vietnamese: [viXTTS](https://huggingface.co/capleaf/viXTTS). Model is a fine-tuned version of the phenomenal <i>Coqui XTTS</i>.
  - New Piper voices for English, Persian, Slovenian, Turkish, French and Spanish
  - New RHVoice voice for Czech
  - Settings option to enable/disable speech synchronization with subtitle timestamps. This may be useful for creating voice overs.
  - Mixing speech with audio from an existing file. When exporting to a file, you can overlay speech with audio from an existing media file. This can be useful when creating voice overs from subtitles.
  - Context menu option to read from cursor position or read only selected text. To activate context menu use mouse right click.
  - Speech audio is always normalized after TTS processing.
  - Fix: Mimic3 models could not be downloaded.
- Translator
  - New models: Greek to English, Maltese to English, Slovenian to English, Turkish to English, English to Catalan
  - Updated models: Czech and Lithuanian
  - Handy buttons to quickly add translated text to the note or to replace it and switch languages
  - Context menu option to translate from cursor position or translate only selected text. To activate context menu use mouse right click.
- Accessibility
  - New <i>Actions</i> for STT/TTS models switching: <i>switch-to-next-stt-model</i>, <i>switch-to-prev-stt-model</i>, <i>switch-to-next-tts-model</i>, <i>switch-to-prev-tts-model</i>, <i>set-stt-model</i>, <i>set-tts-model</i>
  - New global keyboard shortcuts for STT/TTS models switching (X11 only): <i>Switch to next STT model</i>, <i>Switch to prev STT model</i>, <i>Switch to next TTS model</i>, <i>Switch to prev TTS model</i>
  - Toggle option for keyboard shortcuts (X11 only). When <i>Toggle behavior</i> is enabled, Start listening/reading shortcuts will also stop listening/reading if they are triggered while listening/reading is active.
  - Fix: Accented characters (e.g.: ã, ê) were not transferred correctly to the active window.
- Flatpak
  - Flatpak runtime update to version 5.15-23.08
  - AMD ROCm update to version 5.7.3
  - PyTorch update to version 2.2.1
  - CTranslate2 update to version 4.2.1
  - Faster-Whisper update to version 1.0.2