### PR TITLE
update deprecated boost url

### DIFF
--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -139,7 +139,7 @@ modules:
       - "./b2 -j ${FLATPAK_BUILDER_N_JOBS} install"
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.82.0/source/boost_1_82_0.tar.bz2
+        url: https://archives.boost.io/release/1.82.0/source/boost_1_82_0.tar.bz2
         sha256: a6e1ab9b0860e6a2881dd7b21fe9f737a095e5f33a3a874afc6a345228597ee6
 
   - name: webrtcvad


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
