### PR TITLE
Define target for OpenBLAS x86_64 build

### DIFF
--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -99,7 +99,7 @@ modules:
       arch:
         x86_64:
           config-opts:
-            - -DTARGET=SKYLAKEX
+            - -DTARGET=HASWELL
         aarch64:
           config-opts:
             - -DTARGET=ARMV8

--- a/net.mkiol.SpeechNote.yaml
+++ b/net.mkiol.SpeechNote.yaml
@@ -97,6 +97,9 @@ modules:
     build-options:
       no-debuginfo: true
       arch:
+        x86_64:
+          config-opts:
+            - -DTARGET=SKYLAKEX
         aarch64:
           config-opts:
             - -DTARGET=ARMV8


### PR DESCRIPTION
Based on #89. However the SKYLAKEX target still has AVX512, so change the target to HASWELL. See linked OpenBlas comment in mkiol/dsnote#317.

P.S. Sorry, took too long to build on my laptop, so I wanna see if Flathub can build it for me.